### PR TITLE
fixed default history file

### DIFF
--- a/autoload/w3m/history.vim
+++ b/autoload/w3m/history.vim
@@ -3,7 +3,7 @@
 " Author: yuratomo (twitter @yusetomo)
 
 let g:w3m#history#list = []
-let g:w3m#history#save_file = $home.'\\.vim_w3m_hist'
+let g:w3m#history#save_file = $home.'.vim_w3m_hist'
 let s:w3m_history_load = 0
 
 function! w3m#history#Regist(title, params)

--- a/autoload/w3m/history.vim
+++ b/autoload/w3m/history.vim
@@ -3,7 +3,7 @@
 " Author: yuratomo (twitter @yusetomo)
 
 let g:w3m#history#list = []
-let g:w3m#history#save_file = $home.'.vim_w3m_hist'
+let g:w3m#history#save_file = $HOME.'/.vim_w3m_hist'
 let s:w3m_history_load = 0
 
 function! w3m#history#Regist(title, params)


### PR DESCRIPTION
ホームディレクトリに保存される履歴のファイル名が "\.vim_w3m_hist" となっていたので気になって修正してみました．

一応下記環境での動作確認をしてます．

Max OS X 10.7.3, vim 7.3, w3m 0.5.3
Ubuntu 11.10, vim 7.3.475, w3m 0.5.3
