### PR TITLE
Hover speed-boost

### DIFF
--- a/autoload/w3m.vim
+++ b/autoload/w3m.vim
@@ -763,7 +763,7 @@ if exists('g:w3m#set_hover_on') && g:w3m#set_hover_on > 0
       return
     endif
     let [cline,ccol] = [ line('.'), col('.') ]
-    if exists("b:matchHoverLine") && cline == b:matchHoverLine && ccol >= b:matchHoverColStart  && ccol < b:matchHoverColEnd
+    if exists("b:match_hover_line") && cline == b:match_hover_line && ccol >= b:match_hover_col_start  && ccol < b:match_hover_col_end
       " the link under the cursor has not changed
       return
     endif
@@ -786,19 +786,19 @@ if exists('g:w3m#set_hover_on') && g:w3m#set_hover_on > 0
         break
       endif
     endfor
-    if exists('b:matchHoverID') 
+    if exists('b:match_hover_id') 
       " restore color
-      silent! call matchdelete(b:matchHoverID)
-      unlet b:matchHoverID
-      unlet b:matchHoverLine
-      unlet b:matchHoverColStart
-      unlet b:matchHoverColEnd
+      silent! call matchdelete(b:match_hover_id)
+      unlet b:match_hover_id
+      unlet b:match_hover_line
+      unlet b:match_hover_col_start
+      unlet b:match_hover_col_end
     endif
     if tstart != -1 && tstart < tend
-       let b:matchHoverID = matchadd('w3mLinkHover', '\%>'.tstart.'c\%<'.tend.'c\%'.cline.'l')
-       let b:matchHoverLine = cline
-       let b:matchHoverColStart = tstart
-       let b:matchHoverColEnd = tend
+       let b:match_hover_id = matchadd('w3mLinkHover', '\%>'.tstart.'c\%<'.tend.'c\%'.cline.'l')
+       let b:match_hover_line = cline
+       let b:match_hover_col_start = tstart
+       let b:match_hover_col_end = tend
     endif
   endfunction
 endif

--- a/autoload/w3m.vim
+++ b/autoload/w3m.vim
@@ -763,7 +763,7 @@ if exists('g:w3m#set_hover_on') && g:w3m#set_hover_on > 0
       return
     endif
     let [cline,ccol] = [ line('.'), col('.') ]
-    if exists("b:matchHoverLine") && cline == b:matchHoverLine && ccol >= b:matchHoverColStart && ccol <= b:matchHoverColEnd
+    if exists("b:matchHoverLine") && cline == b:matchHoverLine && ccol >= b:matchHoverColStart  && ccol < b:matchHoverColEnd
       " the link under the cursor has not changed
       return
     endif
@@ -777,7 +777,7 @@ if exists('g:w3m#set_hover_on') && g:w3m#set_hover_on > 0
         let start_found = 1
         continue
       endif
-      if start_found > 0 && tag.col > ccol
+      if start_found > 0 && tag.col > ccol && tag.type == s:TAG_END
         let tend = tag.col
         break
       endif

--- a/autoload/w3m.vim
+++ b/autoload/w3m.vim
@@ -447,12 +447,15 @@ endfunction
 function! s:analizeOutputs(output_lines)
   let display_lines = []
   let b:tag_list = []
+  let b:link_index_list = []
   let b:form_list = []
 
   let cline = 1
+  let tnum  = 0
   for line in a:output_lines
     let analaized_line = ''
     let [lidx, ltidx, gtidx] = [ 0, -1, -1 ]
+    let line_list = []
     while 1
       let ltidx = stridx(line, '<', lidx)
       if ltidx >= 0
@@ -476,6 +479,11 @@ function! s:analizeOutputs(output_lines)
               \ 'echecked':0
               \ }
           call add(b:tag_list, item)
+          if tname == 'a'
+            " A link/anchor has been found
+            call add( line_list, tnum)
+          endif
+          let tnum += 1
           if stridx(tname,'input') == 0
             call add(b:form_list, item)
           endif
@@ -490,6 +498,7 @@ function! s:analizeOutputs(output_lines)
       endif
     endwhile
     call add(display_lines, analaized_line)
+    call add(b:link_index_list, line_list)
     let cline += 1
   endfor
   return display_lines
@@ -585,6 +594,7 @@ function! s:prepare_buffer()
     let b:history = []
     let b:display_lines = []
     let b:tag_list = []
+    let b:link_index_list = []
     let b:form_list = []
     let b:click_with_shift = 0
     let b:last_match_id = -1


### PR DESCRIPTION
Improvements to the speed of the link "hover" highlighting.

A new variable `b:link_index_list` was created for this task. 

```
" example:
" on line 55, extract link/anchor #2
link = b:tag_list[b:link_index_list[55][2]]
```

This may also be used to speed up link searches.

**Note**: `matchadd( ... )` is slow. Therefore, `matchadd` is only called if necessary. If the cursor is still within the previous highlighted zone, nothing is changed.
