### PR TITLE
Fix for E119: Not enough arguments for function: w3m#Click

### DIFF
--- a/autoload/w3m.vim
+++ b/autoload/w3m.vim
@@ -1300,7 +1300,7 @@ function! w3m#HitAHintStart()
       break
     endif
   endfor
-  cnoremap <buffer> <CR> <CR>:call w3m#Click(0)<CR>:call w3m#HitAHintEnd()<CR>
+  cnoremap <buffer> <CR> <CR>:call w3m#Click(0, 0)<CR>:call w3m#HitAHintEnd()<CR>
   cnoremap <buffer> <ESC> <ESC>:call w3m#HitAHintEnd()<CR>
   nnoremap <buffer> <ESC> <ESC>:call w3m#HitAHintEnd()<CR>
   call feedkeys('/@', 'n')


### PR DESCRIPTION
When using the HitAHint feature, you would have an error the first time
you pressed <CR> and would have to press it again.